### PR TITLE
feat: initial tg25/tgno crawling config

### DIFF
--- a/browsertrix-crawler/configs/tgno.yaml
+++ b/browsertrix-crawler/configs/tgno.yaml
@@ -1,19 +1,19 @@
+# Config intended to be used on new tg.no once launched. This page differs from
+# previous iterations (in practice, even if not in theory) by being a single
+# site gradually updated with new content and styling, rather than a new site
+# each year.
 seeds:
   # Crawl content available via navigation and frontpage
   - url: https://www.gathering.org
 include:
   # Basic pages
   - www.gathering.org
-  # Uploads
-  - www.gathering.org/api/wp-content
-  # Rest API routes (if needed)
-  - www.gathering.org/api/?rest_route
 
 # Block calls to our tracking service
 blockRules:
    - url: matomo.gathering.org
 
-collection: tg24
+collection: tgno
 
 behaviors: autoscroll,autoplay,autofetch,siteSpecific
 waitUntil: load,networkidle0
@@ -21,8 +21,9 @@ generateCDX: true
 combineWARCs: true
 saveState: always
 workers: 4
+# TODO: Remove it not needed, hopefully we won't need consent flow on new site
 # Minimal profile that includes consent answers
-profile: /crawls/profiles/tg24.tar.gz
+# profile: /crawls/profiles/tg24.tar.gz
 
 # Make "live" crawling view available at 9037
 newContext: window
@@ -30,4 +31,4 @@ screencastPort: 9037
 
 warcinfo:
   operator: The Gathering
-  hostname: gathering.org
+  hostname: tg.no

--- a/browsertrix-crawler/configs/tgno.yaml
+++ b/browsertrix-crawler/configs/tgno.yaml
@@ -4,14 +4,14 @@
 # each year.
 seeds:
   # Crawl content available via navigation and frontpage
-  - url: https://www.gathering.org
+  - url: https://www.tg.no
 include:
   # Basic pages
-  - www.gathering.org
+  - www.tg.no
 
 # Block calls to our tracking service
 blockRules:
-   - url: matomo.gathering.org
+  - url: matomo.gathering.org
 
 collection: tgno
 
@@ -31,4 +31,4 @@ screencastPort: 9037
 
 warcinfo:
   operator: The Gathering
-  hostname: tg.no
+  hostname: www.tg.no

--- a/wayback/startup.sh
+++ b/wayback/startup.sh
@@ -16,7 +16,7 @@ git clone https://github.com/gathering/go-archive-tg21 || (cd go-archive-tg21 ; 
 git clone https://github.com/gathering/go-archive-tg22 || (cd go-archive-tg22 ; git pull ; git lfs pull ; cd ..)
 git clone https://github.com/gathering/go-archive-tg23 || (cd go-archive-tg23 ; git pull ; git lfs pull ; cd ..)
 git clone https://github.com/gathering/go-archive-tg24 || (cd go-archive-tg24 ; git pull ; git lfs pull ; cd ..)
-git clone https://github.com/gathering/go-archive-tg25 || (cd go-archive-tg25 ; git pull ; git lfs pull ; cd ..)
+git clone https://github.com/gathering/go-archive-tgno || (cd go-archive-tgno ; git pull ; git lfs pull ; cd ..)
 
 cd "$WORKDIR"
 
@@ -26,6 +26,6 @@ cp -r "$SOURCES/go-archive-tg21/browsertrix-crawler/crawls/collections/tg21/" "$
 cp -r "$SOURCES/go-archive-tg22/browsertrix-crawler/tg22/" "$COLLECTIONS/"
 cp -r "$SOURCES/go-archive-tg23/tg23/" "$COLLECTIONS/"
 cp -r "$SOURCES/go-archive-tg24/tg24/" "$COLLECTIONS/"
-cp -r "$SOURCES/go-archive-tg25/tg25/" "$COLLECTIONS/"
+cp -r "$SOURCES/go-archive-tgno/tgno/" "$COLLECTIONS/"
 
 exec /docker-entrypoint.sh $@

--- a/wayback/startup.sh
+++ b/wayback/startup.sh
@@ -16,6 +16,7 @@ git clone https://github.com/gathering/go-archive-tg21 || (cd go-archive-tg21 ; 
 git clone https://github.com/gathering/go-archive-tg22 || (cd go-archive-tg22 ; git pull ; git lfs pull ; cd ..)
 git clone https://github.com/gathering/go-archive-tg23 || (cd go-archive-tg23 ; git pull ; git lfs pull ; cd ..)
 git clone https://github.com/gathering/go-archive-tg24 || (cd go-archive-tg24 ; git pull ; git lfs pull ; cd ..)
+git clone https://github.com/gathering/go-archive-tg25 || (cd go-archive-tg25 ; git pull ; git lfs pull ; cd ..)
 
 cd "$WORKDIR"
 
@@ -25,5 +26,6 @@ cp -r "$SOURCES/go-archive-tg21/browsertrix-crawler/crawls/collections/tg21/" "$
 cp -r "$SOURCES/go-archive-tg22/browsertrix-crawler/tg22/" "$COLLECTIONS/"
 cp -r "$SOURCES/go-archive-tg23/tg23/" "$COLLECTIONS/"
 cp -r "$SOURCES/go-archive-tg24/tg24/" "$COLLECTIONS/"
+cp -r "$SOURCES/go-archive-tg25/tg25/" "$COLLECTIONS/"
 
 exec /docker-entrypoint.sh $@


### PR DESCRIPTION
Plan is to adjust this and merge as soon as possible after tg.no site is live, so that we can start capturing crawls early while site is WIP

This PR
- Includes tgno crawls in default archive image (so that they can be browsed)
- Adds tg.no crawl config to be run via `docker-compose run --rm crawler crawl --config /app/configs/tgno.yaml` or similar (this was used to create current contents of https://github.com/gathering/go-archive-tgno)

First part of: https://github.com/gathering/tgno-frontend/issues/40